### PR TITLE
Fixed imgui push/pop out of sync

### DIFF
--- a/src/KismetDebugger.cpp
+++ b/src/KismetDebugger.cpp
@@ -509,8 +509,6 @@ namespace RC::GUI::KismetDebugger
             }
         }
 
-        ImGui::EndChild();
-
         if (!is_hooked || !context)
             m_last_code = nullptr;
     }


### PR DESCRIPTION
There was a bug in UE4SS that's now been fixed.
I've updated the submodule and removed a call to `ImGui::EndChild()` that appears to have been a hack to get around the bug in UE4SS.