### PR TITLE
Added tooltip and menu item to copy UObject addresses

### DIFF
--- a/include/KismetDebugger.hpp
+++ b/include/KismetDebugger.hpp
@@ -123,6 +123,7 @@ namespace RC::GUI::KismetDebugger
         int m_script_size{};
         int m_index{};
         int m_cur{}; // or -1
+        EExprToken m_current_expr{};
     };
 }
 


### PR DESCRIPTION
Added by request.
Hover to see address, and right-click to open a menu that gives you an option to copy the address.
Only available for FObjectProperty & descendant InstanceVariable & LocalVariable instructions and it gives you the address of the object being referred to, not the address of the pointer in the instance or on the stack.
Also works in the `Locals` pane to the left.
![UE4SS_Main51-Win64-Shipping_FaZhls31eE](https://github.com/trumank/kismet-debugger/assets/91646798/0e9365da-78ef-4000-ba74-e02972909e95)
