### PR TITLE
show more operands for several expression types

### DIFF
--- a/include/KismetDebugger.hpp
+++ b/include/KismetDebugger.hpp
@@ -86,6 +86,7 @@ namespace RC::GUI::KismetDebugger
         auto render() -> void;
 
     private:
+        auto render_object();
         auto render_property();
         auto render_expr() -> EExprToken;
 


### PR DESCRIPTION
This just includes more expression parameters in the disassembly output (function/object names, string and byte literals, jump addresses, etc.) 